### PR TITLE
Making inner class PersistentLocalVolumeInfo protected

### DIFF
--- a/src/main/java/mesosphere/marathon/client/model/v2/PersistentLocalVolume.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/PersistentLocalVolume.java
@@ -25,7 +25,7 @@ public class PersistentLocalVolume extends Volume {
         return ModelUtils.toString(this);
     }
 
-    class PersistentLocalVolumeInfo {
+    protected class PersistentLocalVolumeInfo {
         private Integer size;
 
         public Integer getSize() {


### PR DESCRIPTION
Signed-off-by: PrabhaVeerubhotla <vvlprabha@gmail.com>
 
Modifying access modifier of `PersistentLOcalVolumeInfo` inner class to be able to set the persistent volume size from outside package.