### PR TITLE
fix NPE when a reason is missing for a MarathonException

### DIFF
--- a/src/main/java/mesosphere/marathon/client/MarathonException.java
+++ b/src/main/java/mesosphere/marathon/client/MarathonException.java
@@ -17,8 +17,13 @@ public class MarathonException extends HttpResponseException {
 
 	private static String getDetailedMessage(ErrorResponse response, String reason) {
 		if (response.getMessage() != null && !response.getMessage().equals("")) {
-			StringBuilder newMessage = new StringBuilder(reason);
-			newMessage.append(": ");
+			StringBuilder newMessage = new StringBuilder();
+
+			if (reason != null && !reason.equals("")) {
+				newMessage.append(reason);
+				newMessage.append(": ");
+			}
+
 			newMessage.append(response.getMessage());
 
 			if (response.getDetails() != null && response.getDetails().length > 0) {


### PR DESCRIPTION
This occurs for example if you send a request containing a
validation error, resulting in a HTTP 422 Unprocessable Entity.