### PR TITLE
Fetchable Needs to be Based on Marathon API Artifact

### DIFF
--- a/src/main/java/mesosphere/marathon/client/model/v2/Fetchable.java
+++ b/src/main/java/mesosphere/marathon/client/model/v2/Fetchable.java
@@ -7,7 +7,7 @@ public class Fetchable {
     private Boolean executable;
     private Boolean extract;
     private Boolean cache;
-    private String outputFile;
+    private String destPath;
 
     @Override
     public String toString() {
@@ -46,11 +46,7 @@ public class Fetchable {
         this.cache = cache;
     }
 
-    public String getOutputFile() {
-        return outputFile;
-    }
+    public String getDestPath() { return destPath; }
 
-    public void setOutputFile(String outputFile) {
-        this.outputFile = outputFile;
-    }
+    public void setDestPath(String destPath) { this.destPath = destPath; }
 }

--- a/src/test/groovy/mesosphere/marathon/client/model/v2/AppSpec.groovy
+++ b/src/test/groovy/mesosphere/marathon/client/model/v2/AppSpec.groovy
@@ -121,7 +121,7 @@ class AppSpec extends Specification {
 	!fetch2.executable
 	fetch2.extract
 	fetch2.cache
-	fetch2.outputFile == "newname.zip"
+	fetch2.destPath == "newname.zip"
 
 	//secrets
 	app.secrets.size() == 2
@@ -339,7 +339,7 @@ class AppSpec extends Specification {
 	  "executable": false,
 	  "extract": true,
 	  "cache": true,
-	  "outputFile": "newname.zip"
+	  "destPath": "newname.zip"
 	}
   ],
   "user": "root",


### PR DESCRIPTION

Fixes: https://jira.d2iq.com/browse/COPS-6067

This has always been incorrect in marathon-client    The internal state of Marathon uses `FetchUri` which has `outputFile`,

https://github.com/mesosphere/marathon/blob/master/src/main/scala/mesosphere/marathon/raml/AppConversion.scala#L113

however the RAML defines the external API and the RAML defines `fetch` as `artifact.Artifact[]`

https://github.com/mesosphere/marathon/blame/master/docs/docs/rest-api/public/api/v2/types/app.raml#L194-L195

The RAML definition is 4 years old... and the marathon client definition is 3 years old 
https://github.com/mesosphere/marathon-client/commit/5a126bf032c79e448c694f17d9167602a3e84254


The marathon-client needs to be changed to support https://github.com/mesosphere/marathon/blob/master/docs/docs/rest-api/public/api/v2/types/artifact.raml

This fixes the issue!

Signed-off-by: Ken Sipe <kensipe@gmail.com>